### PR TITLE
Add a Posty 1.x importer

### DIFF
--- a/posty/cli.py
+++ b/posty/cli.py
@@ -3,6 +3,7 @@ import os
 import shutil
 
 from .site import Site
+from .importers import Posty1Importer
 
 
 @click.group()
@@ -64,8 +65,9 @@ def posty1(path):
     """
     Import a Posty 1.x site from PATH
     """
-    click.echo(path)
-    # TODO: write this
+    click.echo('Importing from {}...'.format(path))
+    Posty1Importer(Site(), path).run()
+    click.echo('Done! You will need to make sure to update your templates')
 
 
 if __name__ == '__main__':

--- a/posty/cli.py
+++ b/posty/cli.py
@@ -67,7 +67,12 @@ def posty1(path):
     """
     click.echo('Importing from {}...'.format(path))
     Posty1Importer(Site(), path).run()
-    click.echo('Done! You will need to make sure to update your templates')
+    click.echo('Done!')
+    click.echo((
+        "In each of your posts, I've made blurbs using the first paragraph. "
+        'Adjust to your own taste.'
+    ))
+    click.echo('You will also need to make sure to update your templates.')
 
 
 if __name__ == '__main__':

--- a/posty/import.py
+++ b/posty/import.py
@@ -1,5 +1,0 @@
-"""
-Functions to import from various other static site generators
-"""
-
-# Refactoring idea: make this into its own sub-package and use a plugin system

--- a/posty/importers.py
+++ b/posty/importers.py
@@ -1,0 +1,134 @@
+"""
+Functions to import from various other static site generators
+"""
+# Refactoring idea: make this into its own sub-package and use a plugin system
+
+import abc
+import os
+import shutil
+import yaml
+
+
+class Importer(object):
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(self, site, src_path):
+        """
+        :param site:
+            Site object for the destination
+
+        :param src_path:
+            Path to the thing to import
+        """
+        self.site = site
+        self.src_path = src_path
+
+    @abc.abstractmethod
+    def run(self):
+        raise NotImplementedError
+
+    def ensure_directories(self):
+        for _dir in ('media', 'templates', 'pages', 'posts'):
+            path = os.path.join(self.site.site_path, _dir)
+            if not os.path.exists(path):
+                os.mkdir(path)
+            elif not os.path.isdir(path):
+                raise UnableToImport(
+                    '{} exists but is not a directory'.format(path)
+                )
+
+
+class UnableToImport(RuntimeError):
+    pass
+
+
+class Posty1Importer(Importer):
+    """
+    Importer to pull from a Posty 1.x site
+    """
+    def run(self):
+        self.ensure_directories()
+
+        self.import_media()
+        self.import_templates()
+        self.import_pages()
+        self.import_posts()
+
+    def import_media(self):
+        self._copy_files('_media', 'media')
+
+    def import_templates(self):
+        self._copy_files('_templates', 'templates')
+
+    def import_pages(self):
+        self._copy_files('_pages', 'pages')
+
+    def import_posts(self):
+        src_dir = os.path.join(self.src_path, '_posts')
+        dst_dir = os.path.join(self.site.site_path, 'posts')
+
+        for post in os.listdir(src_dir):
+            src_file = os.path.join(src_dir, post)
+            dst_file = os.path.join(dst_dir, post)
+
+            new_post = self._convert_post(open(src_file).read())
+            with open(dst_file, 'w') as fh:
+                fh.write(new_post)
+
+    def _copy_files(self, src, dst):
+        """
+        Copy all the files in ``src_dir`` into ``dst_dir``. Each given dir
+        should be relative to the source/destination sites
+
+        :param src:
+            Relative path to copy files from in the source Posty 1 site
+
+        :param dst:
+            Relative path to copy files to in the destination Posty 2 site
+        """
+        src_dir = os.path.join(self.src_path, src)
+        dst_dir = os.path.join(self.site.site_path, dst)
+
+        for _file in os.listdir(src_dir):
+            src_path = os.path.join(src_dir, _file)
+            dst_path = os.path.join(dst_dir, _file)
+            print("Copying {} to {}".format(src_path, dst_path))
+            if os.path.isfile(src_path):
+                shutil.copy(src_path, dst_path)
+            elif os.path.isdir(src_path):
+                shutil.copytree(src_path, dst_path)
+            else:
+                print(("  Looks like {} isn't a file nor dir, "
+                       "not copying.").format(src_path))
+
+    def _convert_post(self, old_post):
+        """
+        Converts an old Posty post (a string) into a new-style post with a
+        blurb and updated metadata. Returns a string containing the three YAML
+        documents.
+
+        :param old_post:
+            A string containing the contents of an old post file
+        """
+        old_post = old_post.replace("\r\n", "\n")
+        docs = old_post.split("---\n")
+        new_post = ''
+
+        # Convert the metadata
+        meta = yaml.load(docs[1])
+        meta.setdefault('tags', [])
+        new_post += yaml.dump(meta)
+
+        # Create a blurb out of the first paragraph
+        body = docs[2].strip().split("\n\n")
+        blurb = body[0]
+        rest_of_post = "\n\n".join(body[1:])
+
+        new_post += "---\n"
+        new_post += blurb
+
+        # Drop in the rest of the post
+        new_post += "\n---\n"
+        new_post += rest_of_post
+
+        return new_post

--- a/posty/site.py
+++ b/posty/site.py
@@ -1,13 +1,21 @@
+from collections import Counter
 import os.path
+import yaml
 
 from .config import Config
+from .util import slugify
 
 
 class Site(object):
-    def __init__(self, site_path):
+    def __init__(self, site_path='.'):
         self.site_path = site_path
 
         self._config = None
+        self.payload = {
+            'pages': [],
+            'posts': [],
+            'tags': [],
+        }
 
     @property
     def config(self):
@@ -18,5 +26,120 @@ class Site(object):
         return self._config
 
     def build(self, output_path='build'):
-        # TODO: implement
-        print('Not implemented yet!')
+        raise NotImplementedError
+        self.load()
+        self.render()
+
+    def load(self):
+        """
+        Load the site from files on disk into our internal representation
+        """
+        self._load_pages()
+        self._load_posts()
+
+    def _load_pages(self):
+        pages = []
+        page_dir = os.path.join(self.site_path, 'pages')
+        for filename in os.listdir(page_dir):
+            contents = open(os.path.join(page_dir, filename)).read()
+            _, meta_yaml, body = contents.split("---\n")
+            page = yaml.load(meta_yaml)
+
+            page['body'] = body.strip()
+            page.setdefault('parent')
+
+            pages.append(page)
+        self.payload['pages'] = sorted(pages, key=lambda x: x['title'].lower())
+
+    def _load_posts(self):
+        posts = []
+        tags = []
+
+        # Load each post
+        post_dir = os.path.join(self.site_path, 'posts')
+        for filename in os.listdir(post_dir):
+            contents = open(os.path.join(post_dir, filename)).read()
+            parts = contents.split("---\n")
+
+            post = yaml.load(parts[0])
+            post['date'] = post['date'].isoformat()
+            post.setdefault('tags', [])
+
+            if len(parts[1:]) == 1:
+                post['blurb'] = parts[1]
+                post['body'] = parts[1]
+            elif len(parts[1:]) == 2:
+                post['blurb'] = parts[1]
+                post['body'] = "\n".join(parts[1:])
+            else:
+                raise RuntimeError(
+                    "Got too many YAML documents in {}".format(filename)
+                )
+
+            post['blurb'] = post['blurb'].strip()
+            post['body'] = post['body'].strip()
+
+            for tag in post['tags']:
+                tags.append(tag)
+
+            posts.append(post)
+        self.payload['posts'] = sorted(posts, key=lambda x: x['date'],
+                                       reverse=True)
+
+        # uniquify tags and sort by frequency (descending)
+        self.payload['tags'] = [t for t, c in Counter(tags).most_common()]
+
+    def render(self, output_path='build'):
+        """
+        Renders the site as JSON and HTML
+        """
+        raise NotImplementedError   # TODO: implement
+
+    def post(self, slug):
+        """
+        Returns a post by its slug
+
+        :param slug:
+            slug of the post to find
+
+        :returns:
+            A post dict
+
+        :raises RuntimeError:
+            if no post could be found
+        """
+        for post in self.payload['posts']:
+            if slug == slugify(post['title']):
+                return post
+        else:
+            raise RuntimeError(
+                'Unable to find post {}. Available posts: {}'.format(
+                    slug,
+                    [slugify(p['title']) for p in self.payload['pages']]
+                )
+            )
+
+    def page(self, slug):
+        """
+        Returns a page by its slug
+
+        :param slug:
+            slug of the page to find
+
+        :returns:
+            A page dict
+
+        :raises RuntimeError:
+            if no page could be found
+        """
+        for page in self.payload['pages']:
+            if slug == page.get('slug') or slug == slugify(page['title']):
+                return page
+        else:
+            raise RuntimeError(
+                'Unable to find post {}. Available posts: {}'.format(
+                    slug,
+                    [p.get('slug') or slugify(p['title'])
+                        for p in self.payload['title']]
+                )
+            )

--- a/posty/test/fixtures/__init__.py
+++ b/posty/test/fixtures/__init__.py
@@ -1,0 +1,15 @@
+import os.path
+import pytest
+import shutil
+
+
+@pytest.fixture
+def posty1_site_path():
+    return os.path.join(os.path.dirname(__file__), 'posty1_site')
+
+
+@pytest.fixture
+def empty_posty_site():
+    path = tempfile.mkdtemp(suffix='posty-test')
+    yield Site(path)
+    shutil.rmtree(path)

--- a/posty/test/fixtures/__init__.py
+++ b/posty/test/fixtures/__init__.py
@@ -1,6 +1,9 @@
 import os.path
 import pytest
 import shutil
+import tempfile
+
+from posty.site import Site
 
 
 @pytest.fixture
@@ -13,3 +16,7 @@ def empty_posty_site():
     path = tempfile.mkdtemp(suffix='posty-test')
     yield Site(path)
     shutil.rmtree(path)
+
+
+# TODO: Create a `posty_site` fixture that is a copy of the fixture sitting
+# inside a tempdir. That way the fixture files are read-only.

--- a/posty/test/fixtures/posty1_site/_media/index.css
+++ b/posty/test/fixtures/posty1_site/_media/index.css
@@ -1,0 +1,10 @@
+body {
+        margin: 0;
+        padding: 0;
+        width: 760px;
+
+        font-family: Helvetica, Verdana, sans-serif;
+
+        margin-left: auto;
+        margin-right: auto;
+}

--- a/posty/test/fixtures/posty1_site/_pages/test-child.yaml
+++ b/posty/test/fixtures/posty1_site/_pages/test-child.yaml
@@ -1,0 +1,7 @@
+---
+title: Test's child
+url: child.html
+parent: Test
+---
+## This is another test page
+### This one should be a child of the first

--- a/posty/test/fixtures/posty1_site/_pages/test.yaml
+++ b/posty/test/fixtures/posty1_site/_pages/test.yaml
@@ -1,0 +1,17 @@
+---
+title: Test
+url: test.html
+---
+### This is a test page
+
+This is an example page. Just put a bunch of markdown here and it'll get turned into an HTML page.
+
+* There's a lot
+* that you can do 
+* with Markdown
+
+		This is some code
+		For example.
+
+> And here's a blockquote.
+> Dandy!

--- a/posty/test/fixtures/posty1_site/_pages/yup.yaml
+++ b/posty/test/fixtures/posty1_site/_pages/yup.yaml
@@ -1,0 +1,9 @@
+---
+title: Yup
+url: yup.html
+---
+## Yup
+
+This sure is a page
+
+> Mmmhmm. Yeap.

--- a/posty/test/fixtures/posty1_site/_posts/multi-paragraph.yaml
+++ b/posty/test/fixtures/posty1_site/_posts/multi-paragraph.yaml
@@ -1,0 +1,9 @@
+---
+date: 2017-01-14
+title: Multi-paragraph Post
+---
+This is a post that has multiple paragraphs, where the first paragraph should get converted into a blurb.
+
+This is the second paragraph, which should be hidden from the blurb.
+
+And a third paragraph, also outside the blurb.

--- a/posty/test/fixtures/posty1_site/_posts/single-paragraph.yaml
+++ b/posty/test/fixtures/posty1_site/_posts/single-paragraph.yaml
@@ -1,0 +1,5 @@
+---
+date: 2017-01-14
+title: Single paragraph post
+---
+This is a post that just has a single paragraph

--- a/posty/test/fixtures/posty1_site/_posts/test.yaml
+++ b/posty/test/fixtures/posty1_site/_posts/test.yaml
@@ -1,0 +1,11 @@
+---
+name: Test Post
+date: 2010-08-31
+---
+## This is a test post
+Nothing to see here, move along.
+
+* Or is there?
+* No, wait, this is just a list.
+
+		echo "crap."

--- a/posty/test/fixtures/posty1_site/_posts/test2.yaml
+++ b/posty/test/fixtures/posty1_site/_posts/test2.yaml
@@ -1,0 +1,7 @@
+---
+name: Test Post 2
+date: 2010-08-30
+---
+## Another test post!
+
+This is one day before the 'first' test post.

--- a/posty/test/fixtures/posty1_site/_templates/base.html
+++ b/posty/test/fixtures/posty1_site/_templates/base.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+	<head>	
+		<title>My website - {% block title %}{% endblock %}</title>
+	</head>
+	
+	<body>
+		<header>
+            <div class="header">
+                <a href="/">My Website</a>
+            </div>
+		</header>
+
+		<nav>
+            <div id="menu">
+                <h1>Menu</h1>
+                <ul>
+                {% for p in sorted_pages %}
+                    {% if p.parent == None %}
+                        <li class="item"><a href="{{p.href}}">{{p.title}}</a></li>
+                    {% else %}
+                        <li class="subitem"><a href="{{p.href}}">{{p.title}}</a></li>
+                    {% endif %}
+                {% endfor %}
+                </ul>
+            </div>
+		</nav>
+		
+		<div id="content">
+			{% block content %}
+			{% endblock %}
+		</div>
+
+		<footer>
+            <div class="footer">
+                <p>Copyright 2010 You</p>
+                <p>Powered by <a href="http://nickpegg.com/pages/posty.html">Posty</a></p>
+            </div>
+		</footer>
+	</body>
+</html>

--- a/posty/test/fixtures/posty1_site/_templates/page.html
+++ b/posty/test/fixtures/posty1_site/_templates/page.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block title %}{{page.title}}{% endblock %}
+
+{% block content %}
+	<div class="post">
+		<span class="postitile">{{page.title}}</a>
+		{{page.content|markdown}}
+	</div>
+{% endblock %}

--- a/posty/test/fixtures/posty1_site/_templates/post.html
+++ b/posty/test/fixtures/posty1_site/_templates/post.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block title %}
+    {{ post.title }}
+{% endblock %}
+
+
+<div class="post">
+    <a class="postitle" href="{{ post.url }}">{{ post.title }}</a>
+    <span class="info">Posted on {{ post.date }}</span>
+    {{ post.body | markdown }}
+</div>

--- a/posty/test/fixtures/posty1_site/_templates/posts.html
+++ b/posty/test/fixtures/posty1_site/_templates/posts.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block title %}
+	Posts
+{% endblock %}
+
+{% block content %}
+    {% for p in posts %}
+        <div class="post">
+            <a class="posttitle" href="{{p.href}}">{{p.title}}</a>
+            <span class="info">Posted on {{p.date}}</span>
+            {{p.body|markdown}}			
+        </div>
+    {% endfor %}
+{% endblock %}

--- a/posty/test/test_import.py
+++ b/posty/test/test_import.py
@@ -1,0 +1,102 @@
+import os
+import pytest
+
+from .fixtures import posty1_site_path, empty_posty_site    # noqa
+from posty.importers import Posty1Importer
+
+
+class TestPosty1Importer(object):
+    @pytest.fixture     # noqa
+    def importer(self, posty1_site_path, empty_posty_site):
+        return Posty1Importer(empty_posty_site, posty1_site_path)
+
+    @pytest.fixture
+    def importer_with_directories(self, importer):
+        importer.ensure_directories()
+        return importer
+
+    def test_ensure_directories(self, importer):
+        importer.ensure_directories()
+
+        dirs = ('posts', 'pages', 'media', 'templates')
+        for _dir in dirs:
+            path = os.path.join(importer.site.site_path, _dir)
+            assert os.path.isdir(path)
+
+    def test_import_media(self, importer_with_directories):
+        """
+        All media should be copied verbatim
+        """
+        importer = importer_with_directories
+        importer.import_media()
+
+        src_path = os.path.join(importer.src_path, '_media')
+        dst_path = os.path.join(importer.site.site_path, 'media')
+        for f in os.listdir(src_path):
+            src_file = open(os.path.join(src_path, f)).read()
+            dst_file = open(os.path.join(dst_path, f)).read()
+            assert src_file == dst_file
+
+    def test_import_templates(self, importer_with_directories):
+        """
+        all templates should be copied verbatim
+        """
+        importer = importer_with_directories
+        importer.import_templates()
+
+        src_path = os.path.join(importer.src_path, '_templates')
+        dst_path = os.path.join(importer.site.site_path, 'templates')
+        for f in os.listdir(src_path):
+            src_file = open(os.path.join(src_path, f)).read()
+            dst_file = open(os.path.join(dst_path, f)).read()
+            assert src_file == dst_file
+
+    def test_import_pages(self, importer_with_directories):
+        """
+        all pages should be copies verbatim
+        """
+        importer = importer_with_directories
+        importer.import_pages()
+
+        src_path = os.path.join(importer.src_path, '_pages')
+        dst_path = os.path.join(importer.site.site_path, 'pages')
+        for f in os.listdir(src_path):
+            src_file = open(os.path.join(src_path, f)).read()
+            dst_file = open(os.path.join(dst_path, f)).read()
+            assert src_file == dst_file
+
+    def test_import_posts(self, importer_with_directories):
+        """
+        all posts should be copied over with blurbs created from their first
+        paragraphs
+        """
+        importer = importer_with_directories
+        importer.import_posts()
+
+        site = importer.site
+        site._load_posts()
+
+        num_posts = len(os.listdir(os.path.join(importer.src_path, '_posts')))
+        assert num_posts == len(site.payload['posts'])
+
+        post = site.post('single-paragraph-post')
+        assert post['title'] == 'Single paragraph post'
+        assert post['blurb'] == post['body']
+        assert post['body'] == ('This is a post that just has a single '
+                                'paragraph')
+
+        post = site.post('multi-paragraph-post')
+        assert post['title'] == 'Multi-paragraph Post'
+        assert post['blurb'] == ('This is a post that has multiple paragraphs,'
+                                 ' where the first paragraph should get '
+                                 'converted into a blurb.')
+        assert post['body'] == """
+This is a post that has multiple paragraphs, where the first paragraph should get converted into a blurb.
+
+This is the second paragraph, which should be hidden from the blurb.
+
+And a third paragraph, also outside the blurb.
+        """.strip()     # noqa
+
+    def test_it_at_least_runs(self, importer):
+        importer.run()


### PR DESCRIPTION
This importer copies all of the media, templates, and pages varbatim,
and then imports the pages making blurbs out of the first paragraph of
each post, as well as updating the metadata as needed.

Now that we have this importer, the `posty import posty1 PATH` command
has been implemented.

I also had to implement a decent amount `Site` to get this to work. \o/