### PR TITLE
Output the site object as a JSON file

### DIFF
--- a/posty/cli.py
+++ b/posty/cli.py
@@ -1,6 +1,4 @@
 import click
-import os
-import shutil
 
 from .site import Site
 from .importers import Posty1Importer
@@ -16,12 +14,8 @@ def init():
     """
     Initialize a Posty site
     """
-    skel_path = os.path.join(os.path.dirname(__file__), 'skel')
-
-    for d in os.listdir(skel_path):
-        src = os.path.join(skel_path, d)
-        if not os.path.exists(d):
-            shutil.copytree(src, d)
+    site = Site()
+    site.init()
 
     click.echo('Posty initialized!')
     click.echo("""

--- a/posty/config.py
+++ b/posty/config.py
@@ -22,6 +22,7 @@ class Config(MutableMapping):
         """
         if not os.path.exists(self.path):
             raise InvalidConfig(
+                self,
                 'Unable to read config at {}'.format(self.path)
             )
 

--- a/posty/site.py
+++ b/posty/site.py
@@ -115,8 +115,12 @@ class Site(object):
         """
         Renders the site as JSON and HTML
         """
+        output_dir = os.path.join(self.site_path, 'build')
+        if not os.path.exists(output_dir):
+            os.mkdir(output_dir)
+
         # Dump JSON
-        json_path = os.path.join(self.site_path, 'site.json')
+        json_path = os.path.join(output_dir, 'site.json')
         with open(json_path, 'w') as f:
             f.write(self.to_json())
 

--- a/posty/site.py
+++ b/posty/site.py
@@ -2,6 +2,7 @@ from collections import Counter
 import copy
 import json
 import os.path
+import shutil
 import yaml
 
 from .config import Config
@@ -28,8 +29,23 @@ class Site(object):
             self._config.load()
         return self._config
 
+    def init(self):
+        """
+        Initialize a new Posty site at the gien path
+        """
+        skel_path = os.path.join(os.path.dirname(__file__), 'skel')
+        for thing in os.listdir(skel_path):
+            src = os.path.join(skel_path, thing)
+            dst = os.path.join(self.site_path, thing)
+            if os.path.exists(dst):
+                print("{} already exists, not overwriting".format(thing))
+            else:
+                if os.path.isdir(src):
+                    shutil.copytree(src, dst)
+                elif os.path.isfile(src):
+                    shutil.copy(src, dst)
+
     def build(self, output_path='build'):
-        raise NotImplementedError
         self.load()
         self.render()
 
@@ -37,6 +53,8 @@ class Site(object):
         """
         Load the site from files on disk into our internal representation
         """
+        self.payload['title'] = self.config['title']
+        self.payload['description'] = self.config['description']
         self._load_pages()
         self._load_posts()
 
@@ -97,7 +115,12 @@ class Site(object):
         """
         Renders the site as JSON and HTML
         """
-        raise NotImplementedError   # TODO: implement
+        # Dump JSON
+        json_path = os.path.join(self.site_path, 'site.json')
+        with open(json_path, 'w') as f:
+            f.write(self.to_json())
+
+        # Render all of the HTML
 
     def post(self, slug):
         """

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -18,5 +18,14 @@ def empty_posty_site():
     shutil.rmtree(path)
 
 
-# TODO: Create a `posty_site` fixture that is a copy of the fixture sitting
-# inside a tempdir. That way the fixture files are read-only.
+@pytest.fixture
+def site():
+    fixture_path = os.path.join(os.path.dirname(__file__), 'site')
+
+    path = os.path.join(tempfile.mkdtemp(suffix='posty-test'), 'site')
+    site = Site(path)
+    shutil.copytree(fixture_path, path)
+
+    yield site
+
+    shutil.rmtree(path)

--- a/tests/fixtures/site/pages/test.yaml
+++ b/tests/fixtures/site/pages/test.yaml
@@ -7,7 +7,7 @@ url: test.html
 This is an example page. Just put a bunch of markdown here and it'll get turned into an HTML page.
 
 * There's a lot
-* that you can do 
+* that you can do
 * with Markdown
 
 		This is some code

--- a/tests/fixtures/site/posts/multi-paragraph.yaml
+++ b/tests/fixtures/site/posts/multi-paragraph.yaml
@@ -1,6 +1,8 @@
-date: 2017-01-14
-tags: []
 title: Multi-paragraph Post
+date: 2017-01-14
+tags:
+    - blah
+    - test
 ---
 This is a post that has multiple paragraphs, where the first paragraph should get converted into a blurb.
 ---

--- a/tests/fixtures/site/posts/test.yaml
+++ b/tests/fixtures/site/posts/test.yaml
@@ -1,6 +1,9 @@
 date: 2010-08-31
 title: Test Post
-tags: []
+tags:
+  - test
+  - test2
+  - lol
 ---
 ## This is a test post
 Nothing to see here, move along.
@@ -8,4 +11,4 @@ Nothing to see here, move along.
 * Or is there?
 * No, wait, this is just a list.
 
-		echo "crap."
+        echo "crap."

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1,13 +1,24 @@
+import json
 import os.path
 
-from posty.site import Site
+from .fixtures import site  # noqa
 
 
-# Site path that points to the skeleton site
-# TODO: make this part of a site fixture instead
-SITE_PATH = os.path.join(os.path.dirname(__file__), '../posty/skel')
+def test_site_loads_config(site):   # noqa
+    assert site.config['title'] == 'Test website'
 
 
-def test_site_loads_config():
-    s = Site(SITE_PATH)
-    assert s.config['title'] == 'My website'
+def test_render_json(site):     # noqa
+    """
+    Verify that Site.render() spits out a valid JSON file
+    """
+    site.load()
+    site.render()
+
+    json_path = os.path.join(site.site_path, 'site.json')
+    blob = json.load(open(json_path))
+    assert blob['title'] == 'Test website'
+
+    assert len(blob['pages']) > 0
+    assert len(blob['posts']) > 0
+    assert len(blob['tags']) > 0

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -15,7 +15,7 @@ def test_render_json(site):     # noqa
     site.load()
     site.render()
 
-    json_path = os.path.join(site.site_path, 'site.json')
+    json_path = os.path.join(site.site_path, 'build', 'site.json')
     blob = json.load(open(json_path))
     assert blob['title'] == 'Test website'
 


### PR DESCRIPTION
Dumps the internal payload dict of the website out to `site.json` in the build directory.