### PR TITLE
Add models for pages and posts

### DIFF
--- a/posty/config.py
+++ b/posty/config.py
@@ -55,6 +55,7 @@ class Config(MutableMapping):
             raise InvalidConfig(self, 'You must set a title')
 
         c.setdefault('description', '')
+        c.setdefault('base_url', '/')
 
         c.setdefault('num_top_tags', 5)
         c.setdefault('num_posts_per_page', 5)

--- a/posty/config.py
+++ b/posty/config.py
@@ -12,7 +12,7 @@ else:
 
 
 class Config(MutableMapping):
-    def __init__(self, path):
+    def __init__(self, path='config.yml'):
         self.path = path
         self.config = {}
 

--- a/posty/exceptions.py
+++ b/posty/exceptions.py
@@ -17,3 +17,7 @@ class UnableToImport(PostyError):
 
 class MalformedInput(PostyError):
     pass
+
+
+class InvalidObject(PostyError):
+    pass

--- a/posty/importers.py
+++ b/posty/importers.py
@@ -9,11 +9,10 @@ import shutil
 import yaml
 
 from .exceptions import UnableToImport
+from .model import ABC
 
 
-class Importer(object):
-    __metaclass__ = abc.ABCMeta
-
+class Importer(ABC):
     def __init__(self, site, src_path):
         """
         :param site:

--- a/posty/model.py
+++ b/posty/model.py
@@ -1,0 +1,75 @@
+import abc
+from future.utils import with_metaclass
+import sys
+
+from .config import Config
+
+
+if sys.version_info >= (3, 3):
+    from collections.abc import MutableMapping
+else:
+    from collections import MutableMapping
+
+
+class ABC(with_metaclass(abc.ABCMeta)):
+        pass
+
+
+class Model(ABC, MutableMapping):
+    """
+    Object to represent a thing stored as YAML, such as a Post or a Page
+    """
+    def __init__(self, payload, config=None):
+        self.payload = payload
+
+        if config is None:
+            self.config = Config().load()
+        else:
+            self.config = config
+
+        self.validate()
+
+    @classmethod
+    @abc.abstractmethod
+    def from_yaml(cls, file_contents, config=None):
+        """
+        Load an object from its YAML file representation
+        """
+        raise NotImplementedError
+
+    def __len__(self):
+        return len(self.payload)
+
+    def __iter__(self):
+        return iter(self.payload)
+
+    def __getitem__(self, key):
+        return self.payload[key]
+
+    def __setitem__(self, key, value):
+        self.payload[key] = value
+
+    def __delitem__(self, key):
+        del self.payload[key]
+
+    def as_dict(self):
+        """
+        Return a true dict representation of this object, suitable for
+        serialization into JSON or YAML
+        """
+        return self.payload
+
+    @abc.abstractmethod
+    def validate(self):
+        """
+        This should be implemented by the child class to verify that all fields
+        that are expected exist on the payload, and set any that aren't
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def url(self):
+        """
+        Returns the URL path to this resource
+        """
+        raise NotImplementedError

--- a/posty/page.py
+++ b/posty/page.py
@@ -1,0 +1,31 @@
+import yaml
+
+from .exceptions import InvalidObject
+from .model import Model
+from .util import slugify
+
+
+class Page(Model):
+    @classmethod
+    def from_yaml(cls, file_contents, config=None):
+        """
+        Return a Page from the given file_contents
+        """
+        meta_yaml, body = file_contents.split("---\n")
+        payload = yaml.load(meta_yaml)
+        payload['body'] = body.strip()
+
+        return cls(payload, config=config)
+
+    def validate(self):
+        required_fields = ('title', 'body')
+        for field in required_fields:
+            if field not in self.payload.keys():
+                raise InvalidObject('This Page does not have a {} set'.format(
+                    field))
+
+        self.payload.setdefault('parent')
+        self.payload.setdefault('slug', slugify(self.payload['title']))
+
+    def url():
+        raise NotImplementedError   # TODO

--- a/posty/page.py
+++ b/posty/page.py
@@ -1,3 +1,7 @@
+from future.standard_library import install_aliases
+install_aliases()   # noqa
+
+from urllib.parse import urljoin
 import yaml
 
 from .exceptions import InvalidObject
@@ -27,5 +31,6 @@ class Page(Model):
         self.payload.setdefault('parent')
         self.payload.setdefault('slug', slugify(self.payload['title']))
 
-    def url():
-        raise NotImplementedError   # TODO
+    def url(self):
+        path = '{}/'.format(self.payload['slug'])
+        return urljoin(self.config['base_url'], path)

--- a/posty/post.py
+++ b/posty/post.py
@@ -1,3 +1,7 @@
+from future.standard_library import install_aliases
+install_aliases()   # noqa
+
+from urllib.parse import urljoin
 import yaml
 
 from .exceptions import InvalidObject
@@ -42,5 +46,10 @@ class Post(Model):
         self.payload.setdefault('tags', [])
         self.payload.setdefault('slug', slugify(self.payload['title']))
 
-    def url():
-        raise NotImplementedError   # TODO
+    def url(self):
+        path = '{}/{:02d}/{}/'.format(
+            self.payload['date'].year,
+            self.payload['date'].month,
+            self.payload['slug']
+        )
+        return urljoin(self.config['base_url'], path)

--- a/posty/post.py
+++ b/posty/post.py
@@ -1,0 +1,46 @@
+import yaml
+
+from .exceptions import InvalidObject
+from .model import Model
+from .util import slugify
+
+
+class Post(Model):
+    @classmethod
+    def from_yaml(cls, file_contents, config=None):
+        """
+        Returns a Post from the given file_contents
+        """
+        parts = file_contents.split("---\n")
+
+        post = yaml.load(parts[0])
+
+        if len(parts[1:]) == 1:
+            # Post that has no blurb, just a body
+            post['blurb'] = parts[1]
+            post['body'] = parts[1]
+        elif len(parts[1:]) == 2:
+            # Post with a blurb and a separate body
+            post['blurb'] = parts[1]
+            post['body'] = "\n".join(parts[1:])
+        else:
+            raise InvalidObject('Got too many YAML documents in post')
+
+        post['blurb'] = post['blurb'].strip()
+        post['body'] = post['body'].strip()
+
+        return cls(post, config=config)
+
+    def validate(self):
+        required_fields = ('title', 'date', 'blurb', 'body')
+        for field in required_fields:
+            if field not in self.payload.keys():
+                raise InvalidObject(
+                    'Post is missing a {} field in the metadata'.format(field)
+                )
+
+        self.payload.setdefault('tags', [])
+        self.payload.setdefault('slug', slugify(self.payload['title']))
+
+    def url():
+        raise NotImplementedError   # TODO

--- a/posty/skel/config.yml
+++ b/posty/skel/config.yml
@@ -1,5 +1,6 @@
 title: My website
 description: Thoughts and stuff
+base_url: /
 
 num_top_tags: 5
 num_posts_per_page: 5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 awesome-slugify~=1.6.5
 click~=6.7
+future~=0.16.0
 PyYAML~=3.12

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -3,7 +3,14 @@ import pytest
 import shutil
 import tempfile
 
+from posty.config import Config
 from posty.site import Site
+
+
+@pytest.fixture
+def config():
+    config_path = os.path.join(os.path.dirname(__file__), 'site', 'config.yml')
+    return Config(path=config_path).load()
 
 
 @pytest.fixture
@@ -14,7 +21,9 @@ def posty1_site_path():
 @pytest.fixture
 def empty_posty_site():
     path = tempfile.mkdtemp(suffix='posty-test')
-    yield Site(path)
+    site = Site(path)
+    site._config = Config()
+    yield site
     shutil.rmtree(path)
 
 

--- a/tests/fixtures/site/config.yml
+++ b/tests/fixtures/site/config.yml
@@ -1,5 +1,6 @@
 title: Test website
 description: Testy testy test test
+base_url: /test/
 
 num_top_tags: 5
 num_posts_per_page: 5

--- a/tests/fixtures/site/pages/test-child.yaml
+++ b/tests/fixtures/site/pages/test-child.yaml
@@ -1,5 +1,4 @@
 title: Test's child
-url: child.html
 parent: Test
 ---
 ## This is another test page

--- a/tests/fixtures/site/pages/test.yaml
+++ b/tests/fixtures/site/pages/test.yaml
@@ -1,5 +1,4 @@
 title: Test
-url: test.html
 ---
 ### This is a test page
 

--- a/tests/fixtures/site/pages/yup.yaml
+++ b/tests/fixtures/site/pages/yup.yaml
@@ -1,5 +1,4 @@
 title: Yup
-url: yup.html
 ---
 ## Yup
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,3 +37,8 @@ class TestCleanConfig(object):
         del config['compat']
         config.clean_config()
         assert config['compat']['redirect_posty1_urls'] is False
+
+    def test_no_base_url(self, config):
+        del config['base_url']
+        config.clean_config()
+        assert config['base_url'] == '/'

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1,0 +1,41 @@
+import os
+import pytest
+
+from posty.exceptions import InvalidObject
+from posty.page import Page
+
+from .fixtures import config    # noqa
+
+
+@pytest.fixture     # noqa
+def page(config):
+    """
+    Basic top-level page (has no parent)
+    """
+    path = os.path.join(os.path.dirname(__file__), 'fixtures', 'site', 'pages',
+                        'test.yaml')
+    contents = open(path).read()
+    return Page.from_yaml(contents, config=config)
+
+
+def test_validation(page):
+    page.validate()     # Should not raise an exception
+
+    assert 'parent' in page.keys()
+    assert page['title'] == 'Test'
+    assert page['slug'] == 'test'
+
+
+def test_no_title(page):
+    del page['title']
+    with pytest.raises(InvalidObject):
+        page.validate()
+
+
+def test_no_parent(page):
+    del page['parent']
+    assert 'parent' not in page.payload.keys()
+
+    page.validate()
+
+    assert 'parent' in page.payload.keys()

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -18,24 +18,29 @@ def page(config):
     return Page.from_yaml(contents, config=config)
 
 
-def test_validation(page):
-    page.validate()     # Should not raise an exception
+class TestValidation(object):
+    def test_basic_case(self, page):
+        page.validate()     # Should not raise an exception
 
-    assert 'parent' in page.keys()
-    assert page['title'] == 'Test'
-    assert page['slug'] == 'test'
+        assert 'parent' in page.keys()
+        assert page['title'] == 'Test'
+        assert page['slug'] == 'test'
 
+    def test_no_title(self, page):
+        del page['title']
+        with pytest.raises(InvalidObject):
+            page.validate()
 
-def test_no_title(page):
-    del page['title']
-    with pytest.raises(InvalidObject):
+    def test_no_parent(self, page):
+        del page['parent']
+        assert 'parent' not in page.payload.keys()
+
         page.validate()
 
+        assert 'parent' in page.payload.keys()
 
-def test_no_parent(page):
-    del page['parent']
-    assert 'parent' not in page.payload.keys()
 
-    page.validate()
+def test_url(page):
+    expected_url = '/test/{}/'.format(page['slug'])
 
-    assert 'parent' in page.payload.keys()
+    assert page.url() == expected_url

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -19,22 +19,29 @@ def post(config):
     return Post.from_yaml(contents, config=config)
 
 
-def test_validation(post):
-    post.validate()     # Should not raise an exception
+class TestValidation(object):
+    def test_basic_case(self, post):
+        post.validate()     # Should not raise an exception
 
-    assert post['date'] == datetime.date(2017, 1, 14)
-    assert post['title'] == 'Multi-paragraph Post'
-    assert post['slug'] == 'multi-paragraph-post'
-    assert sorted(post['tags']) == ['blah', 'test']
+        assert post['date'] == datetime.date(2017, 1, 14)
+        assert post['title'] == 'Multi-paragraph Post'
+        assert post['slug'] == 'multi-paragraph-post'
+        assert sorted(post['tags']) == ['blah', 'test']
 
+    def test_no_title(self, post):
+        del post['title']
+        with pytest.raises(InvalidObject):
+            post.validate()
 
-def test_no_title(post):
-    del post['title']
-    with pytest.raises(InvalidObject):
+    def test_no_tags(self, post):
+        del post['tags']
         post.validate()
+        assert post['tags'] == []
 
 
-def test_no_tags(post):
-    del post['tags']
-    post.validate()
-    assert post['tags'] == []
+def test_url(post):
+    year = post['date'].year
+    month = post['date'].month
+    expected_url = '/test/{}/{:02d}/{}/'.format(year, month, post['slug'])
+
+    assert post.url() == expected_url

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -1,0 +1,40 @@
+import datetime
+import os
+import pytest
+
+from posty.exceptions import InvalidObject
+from posty.post import Post
+
+from .fixtures import config    # noqa
+
+
+@pytest.fixture     # noqa
+def post(config):
+    """
+    Basic post
+    """
+    path = os.path.join(os.path.dirname(__file__), 'fixtures', 'site', 'posts',
+                        'multi-paragraph.yaml')
+    contents = open(path).read()
+    return Post.from_yaml(contents, config=config)
+
+
+def test_validation(post):
+    post.validate()     # Should not raise an exception
+
+    assert post['date'] == datetime.date(2017, 1, 14)
+    assert post['title'] == 'Multi-paragraph Post'
+    assert post['slug'] == 'multi-paragraph-post'
+    assert sorted(post['tags']) == ['blah', 'test']
+
+
+def test_no_title(post):
+    del post['title']
+    with pytest.raises(InvalidObject):
+        post.validate()
+
+
+def test_no_tags(post):
+    del post['tags']
+    post.validate()
+    assert post['tags'] == []

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -22,3 +22,27 @@ def test_render_json(site):     # noqa
     assert len(blob['pages']) > 0
     assert len(blob['posts']) > 0
     assert len(blob['tags']) > 0
+
+
+def test_page_sorting(site):    # noqa
+    """
+    Ensure pages are sorted alphabetically by their title
+    """
+    last = ''
+    for page in site.payload['pages']:
+        assert last < page['title']
+        last = page['title']
+
+
+def test_post_sorting(site):    # noqa
+    """
+    Ensure posts are sorted in reverse chronological order
+    """
+    last = None
+    for post in site.payload['posts']:
+        if last is None:
+            last = post['date']
+            next
+
+        assert last >= post['date']
+        last = post['date']


### PR DESCRIPTION
This creates to new classes: Page and Post which represent those objects. The main goal is to encapsulate the parsing logic in there (rather than in Site) and also provide a `url()` method that we can call from within templates. Having that method is going to be waaay easier than having some custom jinja tag like `{% link_to post %}`.

To support this URL generation, I also added a `base_url` config option. This is in the case that your website doesn't live at the root of the URL, like `https://example.org/blog/` or something.

Also fixes an ABC mishap in `Importer`. Turns out that Python 2 and Python 3 have incompatible ways of specifying metaclasses, which is why I dragged in the `future` lib in here.