### PR TITLE
Add `absolute_url` jinja filter, add ability to use jinja in markdown content

### DIFF
--- a/posty/config.py
+++ b/posty/config.py
@@ -60,19 +60,15 @@ class Config(MutableMapping):
         c.setdefault('description', '')
         c.setdefault('base_url', '/')
 
+        if not c['base_url'].endswith('/'):
+            raise InvalidConfig(self, 'base_url must end with /')
+
         c.setdefault('num_top_tags', 5)
         c.setdefault('num_posts_per_page', 5)
 
         c.setdefault('feeds', {})
         c['feeds'].setdefault('rss', True)
         c['feeds'].setdefault('atom', True)
-
-        if c['feeds']['rss'] or c['feeds']['atom']:
-            if not c.get('full_url'):
-                raise InvalidConfig(
-                    self,
-                    'You must set full_url if generating RSS/Atom feeds'
-                )
 
         c.setdefault('compat', {})
         c['compat'].setdefault('redirect_posty1_urls', False)

--- a/posty/post.py
+++ b/posty/post.py
@@ -58,9 +58,6 @@ class Post(Model):
         )
         return urljoin(self.config['base_url'], path)
 
-    def full_url(self):
-        return urljoin(self.config['full_url'], self.url())
-
     def path_on_disk(self):
         return os.path.join(
             str(self.payload['date'].year),

--- a/posty/renderer/atom.py
+++ b/posty/renderer/atom.py
@@ -14,7 +14,7 @@ class AtomRenderer(FeedRenderer):
         """
         Return the URL to this feed file
         """
-        return urljoin(self.site.config['full_url'], self.filename)
+        return urljoin(self.site.config['base_url'], self.filename)
 
     def output(self):
         """

--- a/posty/renderer/base.py
+++ b/posty/renderer/base.py
@@ -1,11 +1,12 @@
 import abc
+import copy
 from future.utils import with_metaclass
 import os
 
 
 class Renderer(with_metaclass(abc.ABCMeta)):
     def __init__(self, site, output_path='build'):
-        self.site = site
+        self.site = copy.deepcopy(site)
         self.output_path = os.path.join(site.site_path, output_path)
 
     @abc.abstractmethod

--- a/posty/renderer/feed.py
+++ b/posty/renderer/feed.py
@@ -16,11 +16,11 @@ class FeedRenderer(Renderer):
         config = self.site.config
 
         self.feed = FeedGenerator()
-        self.feed.id(config['full_url'])
+        self.feed.id(config['base_url'])
         self.feed.title(config['title'])
         self.feed.author({'name': config['author']})
         self.feed.copyright(self.site.copyright)
-        self.feed.link(href=config['full_url'], rel='alternate')
+        self.feed.link(href=config['base_url'], rel='alternate')
 
         self.feed.link(href=self.url(), rel='self')
 
@@ -45,8 +45,8 @@ class FeedRenderer(Renderer):
         """
         for post in reversed(self.site.payload['posts']):
             entry = self.feed.add_entry()
-            entry.id(post.full_url())
-            entry.link(href=post.full_url())
+            entry.id(post.url())
+            entry.link(href=post.url())
             entry.title(post['title'])
 
             pub_date = datetime.combine(

--- a/posty/renderer/json.py
+++ b/posty/renderer/json.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import copy
 import json
 import os
 
@@ -19,12 +18,12 @@ class JsonRenderer(Renderer):
         }
 
         for page in self.site.payload['pages']:
-            p = copy.deepcopy(page.as_dict())
+            p = page.as_dict()
             p['body'] = markdown(p['body'])
             payload['pages'].append(p)
 
         for post in self.site.payload['posts']:
-            p = copy.deepcopy(post.as_dict())
+            p = post.as_dict()
             p['blurb'] = markdown(p['blurb'])
             p['body'] = markdown(p['body'])
             p['date'] = post['date'].isoformat()

--- a/posty/renderer/rss.py
+++ b/posty/renderer/rss.py
@@ -14,7 +14,7 @@ class RssRenderer(FeedRenderer):
         """
         Return the URL to this feed file
         """
-        return urljoin(self.site.config['full_url'], self.filename)
+        return urljoin(self.site.config['base_url'], self.filename)
 
     def output(self):
         """

--- a/posty/renderer/util.py
+++ b/posty/renderer/util.py
@@ -27,3 +27,13 @@ def media_url_func(site):
         base_path = urljoin(site.config['base_url'], 'media/')
         return urljoin(base_path, path)
     return media_url
+
+
+def absolute_url_func(site):
+    """
+    Returns a markdown filter function that returns an absolute URL for the
+    given relative URL, simply concatenating config['base_url'] with the URL.
+    """
+    def absolute_url(path):
+        return urljoin(site.config['base_url'], path)
+    return absolute_url

--- a/posty/site.py
+++ b/posty/site.py
@@ -147,7 +147,7 @@ class Site(object):
                 'Unable to find post {}. Available posts: {}'.format(
                     slug,
                     [p.get('slug') or slugify(p['title'])
-                        for p in self.payload['title']]
+                        for p in self.payload['pages']]
                 )
             )
 

--- a/posty/skel/config.yml
+++ b/posty/skel/config.yml
@@ -5,10 +5,8 @@ description: Thoughts and stuff
 num_top_tags: 5
 num_posts_per_page: 5
 
-base_url: /
-
-# Full URL used when generating RSS/Atom feeds
-full_url: http://example.org
+# URL of where this site will be hosted, must end with a /
+base_url: http://example.org/
 
 # Set rss or atom to False if you do not want to generate those feeds
 feeds:

--- a/tests/fixtures/site/config.yml
+++ b/tests/fixtures/site/config.yml
@@ -1,8 +1,7 @@
 author: Jimbo Jawn
 title: Test website
 description: Testy testy test test
-base_url: /test/
-full_url: http://example.org/test/
+base_url: http://example.org/test/
 
 num_top_tags: 5
 num_posts_per_page: 5

--- a/tests/fixtures/site/pages/jinja-in-markdown.yaml
+++ b/tests/fixtures/site/pages/jinja-in-markdown.yaml
@@ -1,0 +1,3 @@
+title: Jinja in Markdown!
+---
+We should be able to put jinja {{ "inside of our templates" }} and have it {{ 'render' + ' totally ' + 'normally'}}!

--- a/tests/fixtures/site/templates/simple_page.html
+++ b/tests/fixtures/site/templates/simple_page.html
@@ -1,0 +1,1 @@
+{{ page.body | markdown }}

--- a/tests/renderer/test_html.py
+++ b/tests/renderer/test_html.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from posty.renderer import HtmlRenderer
@@ -17,3 +18,22 @@ def test_it_at_least_doesnt_crash(renderer):
     #
     # Just make sure it doesn't raise and exception or whatever
     renderer.render_site()
+
+
+def test_jinja_in_markdown(renderer):
+    """
+    If we have jinja inside of our markdown, make sure it gets rendered as
+    expected! This allows folks to use Jinja filters inside markdown!
+    """
+    renderer.ensure_output_path()
+    renderer.prepare_content()
+
+    test_page = renderer.site.page('jinja-in-markdown')
+    renderer.render_page(test_page, template_name='simple_page.html')
+
+    output_path = os.path.join(renderer.output_path,
+                               'jinja-in-markdown/index.html')
+    contents = open(output_path).read()
+
+    assert contents == ('<p>We should be able to put jinja inside of our '
+                        'templates and have it render totally normally!</p>')

--- a/tests/renderer/test_util.py
+++ b/tests/renderer/test_util.py
@@ -14,4 +14,9 @@ def test_markdown():
 
 def test_media_url_func(site):  # noqa
     func = util.media_url_func(site)
-    assert func('jawn') == '/test/media/jawn'
+    assert func('jawn') == 'http://example.org/test/media/jawn'
+
+
+def test_absolute_url_func(site):   # noqa
+    func = util.absolute_url_func(site)
+    assert func('jawn/bot') == 'http://example.org/test/jawn/bot'

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -41,6 +41,6 @@ class TestValidation(object):
 
 
 def test_url(page):
-    expected_url = '/test/{}/'.format(page['slug'])
+    expected_url = 'http://example.org/test/{}/'.format(page['slug'])
 
     assert page.url() == expected_url

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -42,6 +42,7 @@ class TestValidation(object):
 def test_url(post):
     year = post['date'].year
     month = post['date'].month
-    expected_url = '/test/{}/{:02d}/{}/'.format(year, month, post['slug'])
+    expected_url = 'http://example.org/test/{}/{:02d}/{}/'.format(year, month,
+                                                                  post['slug'])
 
     assert post.url() == expected_url


### PR DESCRIPTION
First, `base_url` replaces `full_url`. Having them separate was silly.

This new `absolute_url` template filter returns the absolute version of
the passed-in URL. This is just a simple joining of the `base_url` in
config with the URL.

To use things like `media_url` and `absolute_url` in pages and posts, we
need to pre-render those contents as if they were jinja templates before
we pass them through to markdown and into the templates for final
rendering.

This lets users do things like:
```markdown
* Check this out: {{ "img/my_cool_pic.jpg" | media_url}}