### PR TITLE
Add `posty new ...` commands

### DIFF
--- a/posty/cli.py
+++ b/posty/cli.py
@@ -57,6 +57,42 @@ def build(output, config):
     shutil.copytree('media', os.path.join(output, 'media'))
 
 
+@cli.group(name='new')
+def _new():
+    """
+    Create a new post or page
+    """
+    pass
+
+
+@_new.command()
+@click.option(
+    '--name',
+    help='Name of the new page',
+    default='New Page',
+)
+def page(name):
+    """
+    Create a new page from the template
+    """
+    site = Site()
+    site.new_page(name=name)
+
+
+@_new.command()
+@click.option(
+    '--name',
+    help='Name of the new post',
+    default='New Post',
+)
+def post(name):
+    """
+    Create a new page from the template
+    """
+    site = Site()
+    site.new_post(name=name)
+
+
 @cli.group(name='import')
 def _import():
     """

--- a/posty/page.py
+++ b/posty/page.py
@@ -26,6 +26,20 @@ class Page(Model):
 
         return cls(payload, config=config)
 
+    def to_yaml(self):
+        """
+        Returns a string of the YAML and text representation of this Post.
+        This is the reverse of from_yaml
+        """
+        metadata = {'title': self['title']}
+        if self['parent']:
+            metadata['parent'] = self['parent']
+        output = yaml.dump(metadata, default_flow_style=False)
+        output += "---\n"
+        output += self['body']
+
+        return output
+
     def validate(self):
         required_fields = ('title', 'body')
         for field in required_fields:

--- a/posty/post.py
+++ b/posty/post.py
@@ -39,6 +39,32 @@ class Post(Model):
 
         return cls(post, config=config)
 
+    def to_yaml(self):
+        """
+        Returns the YAML and text representation of this Post. This is the
+        reverse of ``from_yaml()``
+        """
+        metadata = {
+            'title': self['title'],
+            'date': self['date'],
+            'tags': self['tags'],
+        }
+        body = self['body']
+
+        output = yaml.dump(metadata, default_flow_style=False)
+
+        if self['blurb'] != self['body']:
+            output += "---\n"
+            output += self['blurb'].strip()
+            output += "\n"
+
+            body = body.replace(self['blurb'], '')
+
+        output += "---\n"
+        output += body.strip()
+
+        return output
+
     def validate(self):
         required_fields = ('title', 'date', 'blurb', 'body')
         for field in required_fields:

--- a/posty/site.py
+++ b/posty/site.py
@@ -191,8 +191,12 @@ class Site(object):
 
         skel_path = os.path.join(os.path.dirname(__file__),
                                  'skel/posts/1970-01-01_new-post.yaml')
+        post = Post.from_yaml(open(skel_path).read(), config=self.config)
+        post['title'] = name
+        post['date'] = date
 
-        shutil.copy(skel_path, post_path)
+        with open(post_path, 'w') as output_file:
+            output_file.write(post.to_yaml())
 
     def new_page(self, name="New Page"):
         """
@@ -208,4 +212,8 @@ class Site(object):
         skel_path = os.path.join(os.path.dirname(__file__),
                                  'skel/pages/new-page.yaml')
 
-        shutil.copy(skel_path, page_path)
+        page = Page.from_yaml(open(skel_path).read(), config=self.config)
+        page['title'] = name
+
+        with open(page_path, 'w') as output_file:
+            output_file.write(page.to_yaml())

--- a/posty/site.py
+++ b/posty/site.py
@@ -1,4 +1,5 @@
 from collections import Counter
+import datetime
 import os.path
 import shutil
 
@@ -175,3 +176,36 @@ class Site(object):
         )
 
         return copyright
+
+    def new_post(self, name="New Post"):
+        """
+        Create a new post in the site directory from the skeleton post
+        """
+        post_dir = os.path.join(self.site_path, 'posts')
+        if not os.path.exists(post_dir):
+            raise PostyError('You must initialize the site first')
+
+        date = datetime.date.today()
+        filename = '{}_{}.yaml'.format(date, slugify(name))
+        post_path = os.path.join(post_dir, filename)
+
+        skel_path = os.path.join(os.path.dirname(__file__),
+                                 'skel/posts/1970-01-01_new-post.yaml')
+
+        shutil.copy(skel_path, post_path)
+
+    def new_page(self, name="New Page"):
+        """
+        Create a new page in the site directory from the skeleton page
+        """
+        page_dir = os.path.join(self.site_path, 'pages')
+        if not os.path.exists(page_dir):
+            raise PostyError('You must initialize the site first')
+
+        filename = '{}.yaml'.format(slugify(name))
+        page_path = os.path.join(page_dir, filename)
+
+        skel_path = os.path.join(os.path.dirname(__file__),
+                                 'skel/pages/new-page.yaml')
+
+        shutil.copy(skel_path, page_path)

--- a/posty/skel/pages/new-page.yaml
+++ b/posty/skel/pages/new-page.yaml
@@ -1,0 +1,4 @@
+title: New Page
+parent: None
+---
+This is your new page. Write what you want here!

--- a/posty/skel/posts/1970-01-01_new-post.yaml
+++ b/posty/skel/posts/1970-01-01_new-post.yaml
@@ -1,0 +1,11 @@
+title: New Post
+date: 1970-01-01
+tags:
+    - tag1
+    - tag2
+---
+This the the summary/first paragraph of your new post
+---
+This is the rest of the post.
+
+Write what you want here!

--- a/tests/fixtures/site/posts/multi-paragraph.yaml
+++ b/tests/fixtures/site/posts/multi-paragraph.yaml
@@ -1,8 +1,8 @@
-title: Multi-paragraph Post
 date: 2017-01-14
 tags:
-    - blah
-    - test
+- blah
+- test
+title: Multi-paragraph Post
 ---
 This is a post that has multiple paragraphs, where the first paragraph should get converted into a blurb.
 ---

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -7,15 +7,19 @@ from posty.page import Page
 from .fixtures import config    # noqa
 
 
+@pytest.fixture
+def page_contents():
+    path = os.path.join(os.path.dirname(__file__), 'fixtures', 'site', 'pages',
+                        'test.yaml')
+    return open(path).read()
+
+
 @pytest.fixture     # noqa
-def page(config):
+def page(config, page_contents):
     """
     Basic top-level page (has no parent)
     """
-    path = os.path.join(os.path.dirname(__file__), 'fixtures', 'site', 'pages',
-                        'test.yaml')
-    contents = open(path).read()
-    return Page.from_yaml(contents, config=config)
+    return Page.from_yaml(page_contents, config=config)
 
 
 class TestValidation(object):
@@ -44,3 +48,7 @@ def test_url(page):
     expected_url = 'http://example.org/test/{}/'.format(page['slug'])
 
     assert page.url() == expected_url
+
+
+def test_to_yaml(page, page_contents):
+    assert page_contents.strip() == page.to_yaml()

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -8,15 +8,19 @@ from posty.post import Post
 from .fixtures import config    # noqa
 
 
+@pytest.fixture
+def post_contents():
+    path = os.path.join(os.path.dirname(__file__), 'fixtures', 'site', 'posts',
+                        'multi-paragraph.yaml')
+    return open(path).read()
+
+
 @pytest.fixture     # noqa
-def post(config):
+def post(config, post_contents):
     """
     Basic post
     """
-    path = os.path.join(os.path.dirname(__file__), 'fixtures', 'site', 'posts',
-                        'multi-paragraph.yaml')
-    contents = open(path).read()
-    return Post.from_yaml(contents, config=config)
+    return Post.from_yaml(post_contents, config=config)
 
 
 class TestValidation(object):
@@ -46,3 +50,7 @@ def test_url(post):
                                                                   post['slug'])
 
     assert post.url() == expected_url
+
+
+def test_to_yaml(post, post_contents):
+    assert post_contents.strip() == post.to_yaml()

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1,3 +1,6 @@
+import datetime
+import os
+
 from .fixtures import site  # noqa
 
 
@@ -32,3 +35,26 @@ def test_post_sorting(site):    # noqa
 def test_copyright(site):   # noqa
     site.load()
     assert site.copyright == 'Copyright 2010 - 2017, Jimbo Jawn'
+
+
+def test_new_page(site):
+    site.new_page()
+    new_page_path = os.path.join(site.site_path, 'pages', 'new-page.yaml')
+    assert os.path.exists(new_page_path)
+
+    site.new_page('Neato page')
+    new_page_path = os.path.join(site.site_path, 'pages', 'neato-page.yaml')
+    assert os.path.exists(new_page_path)
+
+def test_new_post(site):
+    date = datetime.date.today()
+
+    site.new_post()
+    filename = '{}_new-post.yaml'.format(date)
+    expected_path = os.path.join(site.site_path, 'posts', filename)
+    assert os.path.exists(expected_path)
+
+    site.new_post('Neato Post')
+    filename = '{}_neato-post.yaml'.format(date)
+    expected_path = os.path.join(site.site_path, 'posts', filename)
+    assert os.path.exists(expected_path)

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -37,7 +37,7 @@ def test_copyright(site):   # noqa
     assert site.copyright == 'Copyright 2010 - 2017, Jimbo Jawn'
 
 
-def test_new_page(site):
+def test_new_page(site):    # noqa
     site.new_page()
     new_page_path = os.path.join(site.site_path, 'pages', 'new-page.yaml')
     assert os.path.exists(new_page_path)
@@ -46,7 +46,8 @@ def test_new_page(site):
     new_page_path = os.path.join(site.site_path, 'pages', 'neato-page.yaml')
     assert os.path.exists(new_page_path)
 
-def test_new_post(site):
+
+def test_new_post(site):    # noqa
     date = datetime.date.today()
 
     site.new_post()


### PR DESCRIPTION
Two new commands:
* `posty new page`
* `posty new post`

Each take a `--name` argument for the name of the new post/page, defaults to "New Post" or "New Page" respectively.

These commands will take an object from the skeleton files, update them with the title/date as appropriate, and then drop the new file into your site's `pages`/`posts` directory.

To accomplish this, `to_yaml()` methods were added to Page and Post, which is the reverse of `from_yaml()`, returning the YAML and text representation of the object.

Fixes #29 