### PR TITLE
Add Posty1 post URL compatibility

### DIFF
--- a/posty/renderer/__init__.py
+++ b/posty/renderer/__init__.py
@@ -2,6 +2,13 @@ from .atom import AtomRenderer
 from .html import HtmlRenderer
 from .json import JsonRenderer
 from .rss import RssRenderer
+from .posty1_redirect import Posty1RedirectRenderer
 
 
-__all__ = [AtomRenderer, HtmlRenderer, JsonRenderer, RssRenderer]
+__all__ = [
+    'AtomRenderer',
+    'HtmlRenderer',
+    'JsonRenderer',
+    'RssRenderer',
+    'Posty1RedirectRenderer'
+]

--- a/posty/renderer/posty1_redirect.py
+++ b/posty/renderer/posty1_redirect.py
@@ -1,0 +1,37 @@
+import jinja2
+import os
+
+from posty.util import slugify_posty1
+from .base import Renderer
+
+
+class Posty1RedirectRenderer(Renderer):
+    """
+    Renderer which creates pages to redirect old Posty1 URLs to new Posty2 URLs
+
+    Old Posty1 post URLs are in the form of:
+    /:year/:month/:old_slug.html
+
+    Posty2 URLs are in the form of:
+    /:year/:month/:slug/index.html
+    """
+    def render_site(self):
+        template_path = os.path.join(self.site.site_path,
+                                     'templates/redirect.html')
+        template = jinja2.Template(open(template_path).read())
+
+        for post in self.site.payload['posts']:
+            old_dir = os.path.join(
+                self.output_path,
+                str(post['date'].year),
+                str(post['date'].month)
+            )
+            if not os.path.exists(old_dir):
+                os.makedirs(old_dir)
+
+            old_slug = slugify_posty1(post['title'])
+            redirect_filename = os.path.join(old_dir,
+                                             '{}.html'.format(old_slug))
+
+            with open(redirect_filename, 'w') as redirect:
+                redirect.write(template.render(url=post.url()))

--- a/posty/site.py
+++ b/posty/site.py
@@ -7,7 +7,13 @@ from .config import Config
 from .exceptions import PostyError
 from .page import Page
 from .post import Post
-from .renderer import HtmlRenderer, JsonRenderer, RssRenderer, AtomRenderer
+from .renderer import (
+    HtmlRenderer,
+    JsonRenderer,
+    RssRenderer,
+    AtomRenderer,
+    Posty1RedirectRenderer
+)
 from .util import slugify
 
 
@@ -77,6 +83,9 @@ class Site(object):
             RssRenderer(self, output_path=output_path).render_site()
         if self.config['feeds']['atom']:
             AtomRenderer(self, output_path=output_path).render_site()
+
+        if self.config['compat']['redirect_posty1_urls']:
+            Posty1RedirectRenderer(self, output_path=output_path).render_site()
 
     def _load_pages(self):
         pages = []

--- a/posty/skel/templates/redirect.html
+++ b/posty/skel/templates/redirect.html
@@ -1,0 +1,20 @@
+<html>
+    <head>
+        <!-- Try JavaScript first -->
+        <script type="text/javascript">
+            window.location = "{{ url }}";
+        </script>
+
+        <!-- If JavaScript is disabled or not supported, kick it old-school -->
+        <noscript>
+            <meta http-equiv="refresh" content="0; url={{ url }}">
+        </noscript>
+    </head>
+    <body>
+        <!-- If their browser is super-old, just give them a link to click -->
+        <p>
+            This page has moved. If your browser hasn't redirected you already,
+            <a href="{{ url }}">click here</a>.
+        </p>
+    </body>
+</html>

--- a/tests/fixtures/site/templates/redirect.html
+++ b/tests/fixtures/site/templates/redirect.html
@@ -1,0 +1,20 @@
+<html>
+    <head>
+        <!-- Try JavaScript first -->
+        <script type="text/javascript">
+            window.location = "{{ url }}";
+        </script>
+
+        <!-- If JavaScript is disabled or not supported, kick it old-school -->
+        <noscript>
+            <meta http-equiv="refresh" content="0; url={{ url }}">
+        </noscript>
+    </head>
+    <body>
+        <!-- If their browser is super-old, just give them a link to click -->
+        <p>
+            This page has moved. If your browser hasn't redirected you already,
+            <a href="{{ url }}">click here</a>.
+        </p>
+    </body>
+</html>

--- a/tests/renderer/test_posty1.py
+++ b/tests/renderer/test_posty1.py
@@ -1,0 +1,29 @@
+import os
+import pytest
+
+from posty.renderer import Posty1RedirectRenderer
+from posty.util import slugify_posty1
+
+from ..fixtures import site  # noqa
+
+
+@pytest.fixture     # noqa
+def renderer(site):
+    site.load()
+    return Posty1RedirectRenderer(site)
+
+
+def test_it_at_least_doesnt_crash(renderer):
+    renderer.render_site()
+
+
+def test_redirects_exist(renderer):
+    renderer.render_site()
+    for post in renderer.site.payload['posts']:
+        path = os.path.join(
+            renderer.output_path,
+            str(post['date'].year),
+            str(post['date'].month),
+            '{}.html'.format(slugify_posty1(post['title'])),
+        )
+        assert os.path.exists(path)


### PR DESCRIPTION
Adds Posty1RedirectRenderer, which is a special renderer that drops redirect files for all Posty1 URLs
for all posts. Site uses this renderer if `Site.config['compat']['redirect_posty1_urls']` is set to be true.