### PR TITLE
Refactor jinja-in-markdown rendering to be global

### DIFF
--- a/posty/renderer/feed.py
+++ b/posty/renderer/feed.py
@@ -5,7 +5,7 @@ from feedgen.feed import FeedGenerator
 import pytz
 
 from .base import Renderer
-from .util import markdown
+from .util import markdown_func
 
 
 class FeedRenderer(Renderer):
@@ -55,6 +55,7 @@ class FeedRenderer(Renderer):
             )
             entry.published(pub_date)
 
+            markdown = markdown_func(self.site)
             entry.summary(markdown(post['blurb']))
             entry.content(markdown(post['body']))
 

--- a/posty/renderer/html.py
+++ b/posty/renderer/html.py
@@ -8,7 +8,7 @@ from urllib.parse import urljoin
 
 from .. import util
 from .base import Renderer
-from .util import markdown, media_url_func, absolute_url_func
+from .util import markdown_func, media_url_func, absolute_url_func
 
 # Route reference
 # /               Posts
@@ -41,7 +41,7 @@ class HtmlRenderer(Renderer):
         )
 
         filters = self.jinja_env.filters
-        filters['markdown'] = markdown
+        filters['markdown'] = markdown_func(self.site)
         filters['media_url'] = media_url_func(self.site)
         filters['absolute_url'] = absolute_url_func(self.site)
 
@@ -55,8 +55,6 @@ class HtmlRenderer(Renderer):
 
         :param site: a loaded Site object
         """
-        self.prepare_content()
-
         for post in self.site.payload['posts']:
             self.render_post(post)
 
@@ -65,21 +63,6 @@ class HtmlRenderer(Renderer):
 
         self.render_site_posts()
         self.render_site_tags()
-
-    def prepare_content(self):
-        """
-        Do a first-pass rendering of each post and page text, treating the text
-        as Jinja2 templates. This lets us use basic jinja in the markdown to
-        be able to use filter functions like this:
-
-        ``{{ "img/cool_pic.jpg" | media_url }}``
-        """
-        for page in self.site.payload['pages']:
-            page['body'] = self.jinja_env.from_string(page['body']).render()
-
-        for post in self.site.payload['posts']:
-            post['blurb'] = self.jinja_env.from_string(post['blurb']).render()
-            post['body'] = self.jinja_env.from_string(post['body']).render()
 
     def render_posts(self, posts, prefix='', template_name='posts.html'):
         """

--- a/posty/renderer/json.py
+++ b/posty/renderer/json.py
@@ -4,7 +4,7 @@ import json
 import os
 
 from .base import Renderer
-from .util import markdown
+from .util import markdown_func
 
 
 class JsonRenderer(Renderer):
@@ -23,6 +23,8 @@ class JsonRenderer(Renderer):
             'pages': [],
             'posts': [],
         }
+
+        markdown = markdown_func(self.site)
 
         for page in self.site.payload['pages']:
             p = page.as_dict()

--- a/tests/renderer/test_html.py
+++ b/tests/renderer/test_html.py
@@ -26,7 +26,6 @@ def test_jinja_in_markdown(renderer):
     expected! This allows folks to use Jinja filters inside markdown!
     """
     renderer.ensure_output_path()
-    renderer.prepare_content()
 
     test_page = renderer.site.page('jinja-in-markdown')
     renderer.render_page(test_page, template_name='simple_page.html')

--- a/tests/renderer/test_util.py
+++ b/tests/renderer/test_util.py
@@ -3,12 +3,12 @@ from posty.renderer import util
 from ..fixtures import site  # noqa
 
 
-def test_markdown():
+def test_markdown(site):    # noqa
     """
     Really basic test. No need to test markdown itself, just our use of it
     """
     fenced = "```\nfarts.\n```"
-    result = util.markdown(fenced)
+    result = util.markdown_func(site)(fenced)
     assert result == "<pre><code>farts.\n</code></pre>"
 
 
@@ -20,3 +20,16 @@ def test_media_url_func(site):  # noqa
 def test_absolute_url_func(site):   # noqa
     func = util.absolute_url_func(site)
     assert func('jawn/bot') == 'http://example.org/test/jawn/bot'
+
+
+def test_jinja_in_markdown(site):   # noqa
+    """
+    If we have jinja inside of our markdown, make sure it gets rendered as
+    expected! This allows folks to use Jinja filters inside markdown!
+    """
+    site.load()
+    test_page = site.page('jinja-in-markdown')
+    contents = util.markdown_func(site)(test_page['body'])
+
+    assert contents == ('<p>We should be able to put jinja inside of our '
+                        'templates and have it render totally normally!</p>')


### PR DESCRIPTION
I found that RSS feeds had un-jinja-rendered content because the
jinja-in-markdown rendering was only happening in the HtmlRenderer. It
should be global, so the markdown filter function now takes care of this
rather than HtmlRenderer, so that _all_ renderers get it.